### PR TITLE
tsm 24 fix hooks

### DIFF
--- a/.github/workflows/publish-on-push.yml
+++ b/.github/workflows/publish-on-push.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 16.10.0
       - run: npm ci
-      - run: npm run build
+      - run: npm run build:ci
 
       - id: publish
         uses: JS-DevTools/npm-publish@v1

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "mv:lib": "mv lib dist/ts-mockito/",
     "cp:pkjson": "cp -rf package.json dist/ts-mockito/",
     "cp:all": "npm run cp:readme && npm run cp:license && npm run cp:pkjson",
-    "build": " npm run bump && npm run compile && npm run mkdir:dist && npm run cp:all && npm run mv:lib",
+    "build": "npm run bump && npm run compile && npm run mkdir:dist && npm run cp:all && npm run mv:lib",
+    "build:ci": "npm run compile && npm run mkdir:dist && npm run cp:all && npm run mv:lib",
     "bump": "npm version patch --force"
   },
   "author": "kuster.maciej@gmail.com",


### PR DESCRIPTION
- Remove warning message from Jest
- Bumped all dependencies, removed PhantomJS.
- Fixes byCallIndex error messages
- Added anything() to readme
- Added spec for case when last function has been called but method was not called at all
- Fixed readme with wrong information about atMost validator
- objectContaining matcher to output object representation when a test is failing
- Added better verification message feature from @johanblumenbergs fork
- Rename @cspotcode org to @ts-mockito
- merged changes from nagrock-master
- upgraded ts to latest + upgraded karma
- test(issue15): added the failing tests of issue 15
- switch to typestrong npm scope
- test(issue15): runtime fix
- feat(mocker): removed rxjs
- feat(*): run actions per PR
- feat(*): run actions per push
- feat(*): run actions per push
- 2.6.1
- 2.6.2
- 2.6.3
- fix(*): fixed vulns
- fix(*): updated versions and removed redundancies
- fix(publish): restructure the publish back to original structure
- fix(publish): fixed lock file
- fix(publish): wired publish hook
- fix(publish): fixing publish hook
